### PR TITLE
fix: normalize CRLF on stdin in MCP wrapper

### DIFF
--- a/backend/mcp_wrapper.py
+++ b/backend/mcp_wrapper.py
@@ -26,12 +26,15 @@ def main():
     import threading
     
     def forward_stdin():
-        """Forward stdin to the subprocess, normalizing line endings."""
+        """Forward stdin to the subprocess, normalizing CRLF to LF."""
         try:
             while True:
                 data = sys.stdin.buffer.read(1)
                 if not data:
                     break
+                # Skip \r characters (convert CRLF to LF)
+                if data == b'\r':
+                    continue
                 process.stdin.write(data)
                 process.stdin.flush()
         except Exception:


### PR DESCRIPTION
## What changed
- Updated `backend/mcp_wrapper.py` so stdin forwarding now normalizes CRLF to LF by skipping `\r` bytes.
- Kept existing stdout normalization behavior unchanged.
- Updated the stdin helper docstring to match actual behavior.

## Why
- The wrapper’s purpose is to avoid stream framing issues caused by CRLF line endings.
- Before this change, only stdout was normalized; stdin still passed raw `\r` bytes through.
- Normalizing stdin and stdout consistently reduces protocol parsing issues on Windows clients.

## Testing
- `scripts/clone_and_test.sh Dataojitori/nocturne_memory`
- Tests: not run (no tests found)
