### PR TITLE
fix(db): enable WAL journal mode and busy_timeout for SQLite

### DIFF
--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -64,6 +64,9 @@ class DatabaseManager:
             def set_sqlite_pragma(dbapi_connection, connection_record):
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA foreign_keys=ON")
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA busy_timeout=5000")
+                cursor.execute("PRAGMA synchronous=NORMAL")
                 cursor.close()
 
         self.async_session = async_sessionmaker(


### PR DESCRIPTION
Under concurrent access from multiple MCP clients (several Claude Code
instances + Codex + the SSE server), the default rollback-journal mode
with busy_timeout=0 caused cross-connection snapshot invisibility: a
memory written on one connection was intermittently not found when read
back on another ("write succeeds but read misses").

Set three PRAGMAs in the SQLite connect hook:
- journal_mode=WAL    readers see committed writes across connections
- busy_timeout=5000   wait instead of immediate SQLITE_BUSY on contention
- synchronous=NORMAL  safe, standard pairing with WAL

Verified: a memory created via the MCP is immediately visible to an
independent sqlite3 process on a separate connection.
