### PR TITLE
Kimi Code 兼容性改进

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -460,10 +460,10 @@ async def create_memory(
     disclosure: Annotated[str, Field(
         description="A short trigger condition describing WHEN to recall this memory (must be an input/output signal, e.g. 'When the user mentions...')."
     )],
-    title: Annotated[Optional[str], Field(
+    title: Annotated[str, Field(
         default=None,
         description="Glanceable ENGLISH-ONLY concept name (alphanumeric, hyphens, underscores ONLY)."
-    )] = None,
+    )],
 ) -> str:
     """
     Creates a new memory under a parent URI.


### PR DESCRIPTION
Change title field to be required in memory function
Kimi K2.7/K3 兼容性

Kimi不知道抽什么风，改了MCP的兼容性，顺手改了下以支持Kimi

修改目的：避免产生多个anyOf类型，因为kimi code不支持，然后考虑到title应该不可能会是空白的，所以改成了必填（描述我没改），个人用途中，标题基本上都是会有内容的。

本地测试kimi code 、 claude code 、 codex cli 、 qwen code 、 trae 、 qoder 均正确识别并能正常创建memory